### PR TITLE
Propose: All global namespace methods in PHP prefixed with bluehost in bluehost codebases.

### DIFF
--- a/Bluehost/ruleset.xml
+++ b/Bluehost/ruleset.xml
@@ -77,5 +77,14 @@
 
     <!-- Loads the PHP Compatibility ruleset. -->
     <rule ref="PHPCompatibilityWP"/>
+    
+    <!-- Assures global namespace methods across all products are prefixed with bluehost -->
+    <rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array">
+				<element value="bluehost"/>
+			</property>
+		</properties>
+	</rule>
 
 </ruleset>


### PR DESCRIPTION
As this standard is loaded into multiple WordPress projects, this can help enforce cross-product congruency of `bluehost_$product$_feature_action`